### PR TITLE
Potential fix for code scanning alert no. 3: Missing CSRF middleware

### DIFF
--- a/mainapp/backend/index.js
+++ b/mainapp/backend/index.js
@@ -3,6 +3,7 @@ import dotenv from "dotenv";
 import mongoose from "mongoose";
 import cors from "cors";
 import cookieParser from "cookie-parser";
+import csurf from "csurf";
 import tourRoute from "./routes/tour.js";
 import userRoute from "./routes/user.js";
 import authRoute from "./routes/auth.js";
@@ -38,6 +39,7 @@ const connect = async () => {
 mainapp1.use(express.json());
 mainapp1.use(cors(corsOptions));
 mainapp1.use(cookieParser());
+mainapp1.use(csurf({ cookie: true }));
 mainapp1.use("/api/v1/auth", authRoute);
 mainapp1.use("/api/v1/tours", tourRoute);
 mainapp1.use("/api/v1/users", userRoute);

--- a/mainapp/backend/package.json
+++ b/mainapp/backend/package.json
@@ -20,6 +20,7 @@
     "express": "^4.18.2",
     "jsonwebtoken": "^9.0.0",
     "mongodb": "^5.6.0",
-    "mongoose": "^7.2.3"
+    "mongoose": "^7.2.3",
+    "csurf": "^1.11.0"
   }
 }


### PR DESCRIPTION
Potential fix for [https://github.com/y4-systems/ssd-project/security/code-scanning/3](https://github.com/y4-systems/ssd-project/security/code-scanning/3)

To fix this vulnerability, we should introduce CSRF protection middleware into the request processing pipeline after parsing cookies but before processing sensitive routes. The standard package for Express is `csurf`, which is well-known, actively maintained, and easily integrated.  
The best-practice fix is to import and configure the `csurf` middleware and add it to the app—usually after cookie and body parsers, and before route handlers. If any routes (such as login or public GET endpoints) should be exempt, selectively control where the middleware is applied. In this minimal change, we will enforce CSRF for all routes.

**Files/lines to change**:  
- In `mainapp/backend/index.js`, add the required import for `csurf`.
- Add its middleware after `cookieParser()` and before setting up any route handlers.

**Requirements:**  
- Import `csurf`.
- Add CSRF middleware: `mainapp1.use(csurf({ cookie: true }));`
  - This automatically places the CSRF token in a cookie named `_csrf`.
- Optionally, future modifications might handle token delivery for front-end forms.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
